### PR TITLE
Fix always fails to find "pubspec.lock" on Windows

### DIFF
--- a/bin/formats/about_libraries_format.dart
+++ b/bin/formats/about_libraries_format.dart
@@ -50,9 +50,8 @@ class AboutLibrariesFormat extends FormatHoldable {
   /// Write formated text to file.
   @override
   void write() async {
-    Map environmentVars = Platform.environment;
     String directoryPath =
-        '${environmentVars["PWD"]}/android/app/src/main/res/values';
+        '${Directory.current.path}/android/app/src/main/res/values';
     String fullPath = "$directoryPath/license_strings.xml";
     await new Directory(directoryPath).create(recursive: true);
     var output = """\

--- a/bin/formats/settings_bundle_plist_format.dart
+++ b/bin/formats/settings_bundle_plist_format.dart
@@ -51,9 +51,8 @@ class SettingsBundlePlistFormat extends FormatHoldable {
   /// Write formated text to file.
   @override
   void write() async {
-    Map environmentVars = Platform.environment;
     String directoryPath =
-        '${environmentVars["PWD"]}/ios/Runner/Settings.bundle';
+        '${Directory.current.path}/ios/Runner/Settings.bundle';
     if (FileSystemEntity.typeSync(directoryPath) ==
         FileSystemEntityType.notFound) {
       throw AssertionError(
@@ -83,7 +82,7 @@ ${rootOutput.join("\n")}
     doWrite(file, output);
 
     String subDirectoryPath =
-        '${environmentVars["PWD"]}/ios/Runner/Settings.bundle/com.ko2ic.dart-oss-licenses';
+        '${Directory.current.path}/ios/Runner/Settings.bundle/com.ko2ic.dart-oss-licenses';
     await new Directory(subDirectoryPath).create(recursive: true);
 
     tuples.forEach((tuple) {

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -66,8 +66,7 @@ main(List<String> arguments) async {
 
 /// acquire all the names of the using library.
 Iterable<dynamic> findPluginNames() {
-  Map environmentVars = Platform.environment;
-  String path = '${environmentVars["PWD"]}/pubspec.lock';
+  String path = '${Directory.current.path}/pubspec.lock';
 
   if (FileSystemEntity.typeSync(path) == FileSystemEntityType.notFound) {
     throw AssertionError(


### PR DESCRIPTION
Use `Directory.current.path` instead of environmental variable `PWD`
to support non-POSIX shells.

This Pull request will fix #3.